### PR TITLE
Do not use PropertyInfo.SetValue in some cases

### DIFF
--- a/src/AxaFrance.WebEngine.MobileApp/TestSuiteApp.cs
+++ b/src/AxaFrance.WebEngine.MobileApp/TestSuiteApp.cs
@@ -78,9 +78,20 @@ namespace AxaFrance.WebEngine.MobileApp
                 string packagePath = s.AppId;
                 if (!s.AppId.StartsWith("bs:"))
                 {
-                    var id = AppFactory.UploadAppPackage(s.Username, s.Password, packagePath, s.PackageUploadUrl).Result;
+                    var id = AppFactory.UploadToBrowserstack(packagePath, s.Username, s.Password, s.PackageUploadUrl).Result;
                     s.AppId = id;
                     DebugLogger.WriteLine($"Application Id privided by Browserstack is: {id}");
+                }
+            }
+            else if (s.GridServerUrl.Contains("moiblelab"))
+            {
+                DebugLogger.WriteLine("Test on remote appium compatible server: Mobile Lab Service");
+                string packagePath = s.AppId;
+                if (!s.AppId.StartsWith("http"))
+                {
+                    var id = AppFactory.UploadToMobileLab(s.Password, packagePath, s.PackageUploadUrl).Result;
+                    s.AppId = id;
+                    DebugLogger.WriteLine($"Application Id privided by Mobile Lab service is: {id}");
                 }
             }
             driver = AppFactory.GetDriver(s.Platform);

--- a/src/AxaFrance.WebEngine.Web/PageModel.cs
+++ b/src/AxaFrance.WebEngine.Web/PageModel.cs
@@ -26,8 +26,11 @@ namespace AxaFrance.WebEngine.Web
                 if (p.FieldType.IsSubclassOf(typeof(ElementDescription)))
                 {
                     ElementDescription e = (ElementDescription)p.GetValue(this);
-                    if (e == null) e = (ElementDescription)Activator.CreateInstance(p.FieldType);
-                    p.SetValue(this, e);
+                    if (e == null)
+                    {
+                        e = (ElementDescription)Activator.CreateInstance(p.FieldType);
+                        p.SetValue(this, e);
+                    }
                     CheckFindsByAttribute(p, e);
                     e.UseDriver(driver);
                 }
@@ -39,8 +42,11 @@ namespace AxaFrance.WebEngine.Web
                 if (p.PropertyType.IsSubclassOf(typeof(ElementDescription)))
                 {
                     ElementDescription e = (ElementDescription)p.GetValue(this);
-                    if (e == null) e = (ElementDescription)Activator.CreateInstance(p.PropertyType);
-                    p.SetValue(this, e);
+                    if (e == null)
+                    {
+                        e = (ElementDescription)Activator.CreateInstance(p.PropertyType);
+                        p.SetValue(this, e);
+                    }
                     CheckFindsByAttribute(p, e);
                     e.UseDriver(driver);
                 }

--- a/src/Samples.Gherkin/Features/DrinkMachine.feature.cs
+++ b/src/Samples.Gherkin/Features/DrinkMachine.feature.cs
@@ -26,7 +26,7 @@ namespace Samples.Gherkin.Features
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private string[] _featureTags = ((string[])(null));
+        private static string[] featureTags = ((string[])(null));
         
 #line 1 "DrinkMachine.feature"
 #line hidden
@@ -35,7 +35,7 @@ namespace Samples.Gherkin.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "DrinkMachine", null, ProgrammingLanguage.CSharp, ((string[])(null)));
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "DrinkMachine", null, ProgrammingLanguage.CSharp, featureTags);
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -47,28 +47,28 @@ namespace Samples.Gherkin.Features
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public virtual void TestInitialize()
+        public void TestInitialize()
         {
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public virtual void TestTearDown()
+        public void TestTearDown()
         {
             testRunner.OnScenarioEnd();
         }
         
-        public virtual void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
+        public void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
         {
             testRunner.OnScenarioInitialize(scenarioInfo);
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public virtual void ScenarioStart()
+        public void ScenarioStart()
         {
             testRunner.OnScenarioStart();
         }
         
-        public virtual void ScenarioCleanup()
+        public void ScenarioCleanup()
         {
             testRunner.CollectScenarioErrors();
         }
@@ -76,26 +76,16 @@ namespace Samples.Gherkin.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Let\'s drink some tea")]
         [NUnit.Framework.CategoryAttribute("tag1")]
-        public virtual void LetsDrinkSomeTea()
+        public void LetsDrinkSomeTea()
         {
             string[] tagsOfScenario = new string[] {
                     "tag1"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Let\'s drink some tea", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Let\'s drink some tea", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 4
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
-            bool isScenarioIgnored = default(bool);
-            bool isFeatureIgnored = default(bool);
-            if ((tagsOfScenario != null))
-            {
-                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
-            }
-            if ((this._featureTags != null))
-            {
-                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
-            }
-            if ((isScenarioIgnored || isFeatureIgnored))
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
             {
                 testRunner.SkipScenario();
             }

--- a/src/WebEngine.Test/UnitTests/LoginPage.cs
+++ b/src/WebEngine.Test/UnitTests/LoginPage.cs
@@ -17,7 +17,7 @@ namespace WebEngine.Test.UnitTests
         public WebElementDescription TxtPassword = new WebElementDescription();
 
         [FindsBy(How = How.Id, Using = "submit")]
-        public WebElementDescription ButtonSubmit = new WebElementDescription();
+        public WebElementDescription ButtonSubmit { get; set; } = new WebElementDescription();
 
         public WebElementDescription SpanErrorMessage = new WebElementDescription
         {


### PR DESCRIPTION
Do not use PropertyInfo.SetValue if the Property of a `PageModel` is not null.
